### PR TITLE
Don't try to download if empty MD5

### DIFF
--- a/urtupdater.cpp
+++ b/urtupdater.cpp
@@ -544,7 +544,9 @@ void UrTUpdater::parseManifest(QString data){
 
                             // If the file does not exist, it must be downloaded.
                             if(!f->exists()){
-                                mustDownload = true;
+                                if(!fileMd5.isEmpty()){
+                                    mustDownload = true;
+                                }
                             }
 
                             // If the md5 string is empty, it means that the API wants


### PR DESCRIPTION
I just noticed this while writing the server updater and I should note that I haven't tested this (I haven't installed QT5 yet and it takes literally hours to compile...). I could have misread the code, so I apologize if I wasted your time.

It appears to me that if the MD5 for a file from the manifest was empty but did not exist on the client, it would try to download it anyway. (This could arise if the user manually deleted the file or if they upgraded from a version without that file to a version that deletes that file without having upgraded to the version in between that presumably contained the file in the first place.) I assume the URL would be blank for these and it would fail when it tries to download anyway but if that's not the case this should stop that from happening in the first place.