### PR TITLE
Don't allow the updater to run in /Applications/ on MacOS

### DIFF
--- a/urtupdater.cpp
+++ b/urtupdater.cpp
@@ -176,6 +176,36 @@ void UrTUpdater::init(){
             return;
         }
 
+        // OSX: Staring the updater in /Applications/ will be a mess.
+        // We'll ask the user if he allows us to move on a subdir called UrbanTerror.
+        if (updaterPath == "/Applications/"){
+            msg.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+            msg.setIcon(QMessageBox::Information);
+            msg.setText("I'm sorry, but I can't run in /Applications/. I will create a big mess if I'm not in a subfolder (or somewhere else)\n\nDo you allow me to create a subfolder called UrbanTerror in /Applications/ and move myself into it ?");
+            result = msg.exec();
+
+            // User don't want us to move. But we don't want to mess inside the /Applications/ folder, so we quit.
+            if(result == QMessageBox::Cancel){
+                exit(0); 
+            }
+
+            if(!QDir().mkdir("/Applications/UrbanTerror/")){
+                QMessageBox::critical(this, "Can't create subfolder in /Applications/", "I can't create the folder \"/Applications/UrbanTerror/\"\n\nIt's probably because the folder already exist or because you do not have the permission to create it."  );
+
+                exit(0);
+            }                    
+            if(!QDir().rename(getBundlePath(), "/Applications/UrbanTerror/UrTUpdater.app")){
+                QMessageBox::critical(this, "Can't move the updater to /Applications/UrbanTerror/", "I failed to move myself into the UrbanTerror subfolder."  );
+                
+                exit(0);
+            }
+
+            // Now we exec the updater from the new location and we can leave, gracefuly
+            QProcess::startDetached("open \"/Applications/UrbanTerror/UrTUpdater.app\"");
+
+            exit(0);
+        }
+
         msg.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
         msg.setIcon(QMessageBox::Information);
         msg.setText("The game " URT_GAME_NAME " will be installed in this path:\n\n" + updaterPath + "\n\n"
@@ -224,6 +254,20 @@ QString UrTUpdater::getCurrentPath(){
     // We need to cd ../../..
     if(getPlatform() == "Mac"){
         dir.cdUp();
+        dir.cdUp();
+        dir.cdUp();
+    }
+
+    return dir.absolutePath() + "/";
+}
+
+QString UrTUpdater::getBundlePath(){
+    QDir dir = QDir(QCoreApplication::applicationDirPath());
+
+    // If we're on Mac, 'dir' will contain the path to the executable
+    // inside of the Updater's bundle which isn't what we want.
+    // We need to cd ../..
+    if(getPlatform() == "Mac"){
         dir.cdUp();
         dir.cdUp();
     }

--- a/urtupdater.h
+++ b/urtupdater.h
@@ -53,6 +53,7 @@ public slots:
 
     QString getPlatform();
     QString getCurrentPath();
+    QString getBundlePath();
 
     void parseAPIAnswer();
     void getManifest(QString query);


### PR DESCRIPTION
Running the updater inside /Applications/ is a bad idea because of how the Updater works.

With this fix, if the user run the updater in /Applications/ it will ask if it can create the folder /Applications/UrbanTerror/ and move itself inside before restarting it.

