### PR TITLE
Replace cat by sed filter if no text html browser in ded.

### DIFF
--- a/ded/UrTUpdater_Ded.sh
+++ b/ded/UrTUpdater_Ded.sh
@@ -18,6 +18,7 @@ UPDATERVERSION=${UPDATERVERSION:-4.0.3}
 APIURL="http://www.urbanterror.info/api/updaterv4/"
 URT_GAME_SUBDIR=${URT_GAME_SUBDIR:-q3ut4}
 BROWSER=${BROWSER:-}
+SEDHTMLFILTER='s/< *[aA] *[Hh][Rr][Ee][Ff] *= *"\([^"]*\)"[^>]*>/\n ---> \1 =\n/g;s/<[^>]*>//g'
 #PLATFORM=${PLATFORM:-Linux32}
 
 if [ -z "$PLATFORM" ]; then
@@ -242,7 +243,7 @@ function doBrowser ()
     echo "$1" > "$TMPFILE"
 
     if [ -z "$BROWSER" ]; then
-        cat "$TMPFILE"
+        sed -e "$SEDHTMLFILTER" "$TMPFILE" | more
     else
         $BROWSER "$TMPFILE"
     fi


### PR DESCRIPTION
In desktop Linux, usually there is no text html browser (lynx, elinks, etc) installed as the graphical desktop is used. So, if ded updater is used from any Linux, then the html files (news, license, etc.) should be shown in text mode at least without html tags, but preserving the links URL. A sed filter paged through more can be used to achieve this, as sed and more are essential commands in any Linux distribution.